### PR TITLE
Allow tests to resume along segment barriers

### DIFF
--- a/tds-itemselection-aironline/src/main/java/tds/itemselection/algorithms/AdaptiveSelector2013.java
+++ b/tds-itemselection-aironline/src/main/java/tds/itemselection/algorithms/AdaptiveSelector2013.java
@@ -190,7 +190,12 @@ public class AdaptiveSelector2013 extends AbstractAdaptiveSelector implements II
                     }
                 }
             }
-            // Allow pauses along segment barriers
+            /*
+             *	If item groups are passed into this method, the method is being leveraged as a selector for
+             *	Multi-Stage Braille (MSB) assessments. Parent group exclusions for adaptive selection are not
+             *	a valid criteria for excluding retrieved item groups. Ignoring exclusion allows tests paused along
+             *	segment barriers to be restarted properly.
+             */
 		    cset1 = csetFactory.MakeCset1 (itemGroups != null);
 			this.blueprint = cset1.getBlueprint ();	
 			

--- a/tds-itemselection-aironline/src/main/java/tds/itemselection/algorithms/AdaptiveSelector2013.java
+++ b/tds-itemselection-aironline/src/main/java/tds/itemselection/algorithms/AdaptiveSelector2013.java
@@ -190,7 +190,8 @@ public class AdaptiveSelector2013 extends AbstractAdaptiveSelector implements II
                     }
                 }
             }
-		    cset1 = csetFactory.MakeCset1 (connection);
+            // Allow pauses along segment barriers
+		    cset1 = csetFactory.MakeCset1 (itemGroups != null);
 			this.blueprint = cset1.getBlueprint ();	
 			
             // Record current ability and information approximations (if there is a AdaptiveThetas listener)

--- a/tds-itemselection-impl/src/main/java/tds/itemselection/impl/item/CsetItem.java
+++ b/tds-itemselection-impl/src/main/java/tds/itemselection/impl/item/CsetItem.java
@@ -136,9 +136,15 @@ public void setContentLevelCollection(
   // / Cset1 factory may remove this item from the pool even though the base
   // item is active
   // / </summary>
+  public boolean isActive (boolean ignoreParent)
+  {
+  return !pruned && this.isActive && !ItemUsed &&
+          (ignoreParent ? true : !_parentGroup.getUsed ());
+  }
+
   public boolean isActive ()
   {
-    return !pruned && !_parentGroup.getUsed () && this.isActive && !ItemUsed;
+    return isActive(false);
   }
 
 //  // / <summary>

--- a/tds-itemselection-impl/src/main/java/tds/itemselection/impl/item/CsetItem.java
+++ b/tds-itemselection-impl/src/main/java/tds/itemselection/impl/item/CsetItem.java
@@ -138,8 +138,8 @@ public void setContentLevelCollection(
   // / </summary>
   public boolean isActive (boolean ignoreParent)
   {
-  return !pruned && this.isActive && !ItemUsed &&
-          (ignoreParent ? true : !_parentGroup.getUsed ());
+    return !pruned && this.isActive && !ItemUsed &&
+          (ignoreParent || !_parentGroup.getUsed ());
   }
 
   public boolean isActive ()

--- a/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/Cset1Factory2013.java
+++ b/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/Cset1Factory2013.java
@@ -117,7 +117,12 @@ public class Cset1Factory2013 {
 
 	  }
 
-	 public Cset1 MakeCset1 (SQLConnection connection) throws ItemSelectionException, ReturnStatusException
+	  public Cset1 MakeCset1() throws ItemSelectionException, ReturnStatusException
+	  {
+		  return MakeCset1(false);
+	  }
+
+	 public Cset1 MakeCset1 (boolean ignoreParent) throws ItemSelectionException, ReturnStatusException
 	  {
 
 		// initialized Pool and created itemGroups!
@@ -136,7 +141,7 @@ public class Cset1Factory2013 {
 	    }
 	    // remove all item groups that are completely pruned or remain in 'used'
 	    // status
-	    itemGroups.removeUsed ();
+	    itemGroups.removeUsed (ignoreParent);
 
 	    ComputeSatisfaction ();
 

--- a/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/CsetGroup.java
+++ b/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/CsetGroup.java
@@ -713,6 +713,11 @@ public double getBpJitter ()
   // / </summary>
   public int getActiveCount ()
   {
+    return getActiveCount(false);
+  }
+
+  public int getActiveCount (boolean ignoreParent)
+  {
     int cnt = 0;
     for (TestItem item : items)
     {
@@ -721,7 +726,7 @@ public double getBpJitter ()
       {
         citem = (CsetItem) item;
       }
-      if (citem != null && citem.isActive ())
+      if (citem != null && citem.isActive (ignoreParent))
         ++cnt;
     }
     return cnt;

--- a/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/CsetGroupCollection.java
+++ b/tds-itemselection-impl/src/main/java/tds/itemselection/impl/sets/CsetGroupCollection.java
@@ -77,10 +77,14 @@ public class CsetGroupCollection
   // / </summary>
   public void removeUsed ()
   {
+    removeUsed(false);
+  }
+
+  public void removeUsed(boolean ignoreParent) {
     List<CsetGroup> remove = new ArrayList<CsetGroup> ();
     for (CsetGroup grp : _groups.values ())
     {
-      if (grp.getActiveCount() == 0)
+      if (grp.getActiveCount(ignoreParent) == 0)
         remove.add (grp);
     }
     for (CsetGroup grp : (Collection<CsetGroup>) remove)


### PR DESCRIPTION
All parent groups are being marked as used when tests resume. These changes allow the algorithm to safely select from active groups and continue previously started exams.