### PR TITLE
Support returning a SATISFIED response from the ItemSelectionService

### DIFF
--- a/tds-item-selection-components/pom.xml
+++ b/tds-item-selection-components/pom.xml
@@ -34,6 +34,18 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>2.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/tds-item-selection-components/src/main/java/tds/itemselection/model/ItemResponse.java
+++ b/tds-item-selection-components/src/main/java/tds/itemselection/model/ItemResponse.java
@@ -9,13 +9,15 @@ import com.google.common.base.Optional;
 public class ItemResponse<T> {
   private final T responseData;
   private final String errorMessage;
+  private final Status responseStatus;
 
   /**
    * @param responseData the data to be included in the response when there are no errors
    */
   public ItemResponse(final T responseData) {
     this.responseData = responseData;
-    this.errorMessage = null;
+    this.errorMessage = responseData == null ? "Null response data" : null;
+    this.responseStatus = responseData == null ? Status.FAILURE : Status.SUCCESS;
   }
 
   /**
@@ -24,6 +26,16 @@ public class ItemResponse<T> {
   public ItemResponse(final String errorMessage) {
     this.responseData = null;
     this.errorMessage = errorMessage;
+    this.responseStatus = Status.FAILURE;
+  }
+
+  /**
+   * @param responseStatus the response status
+   */
+  public ItemResponse(final Status responseStatus) {
+    this.responseData = null;
+    this.errorMessage = null;
+    this.responseStatus = responseStatus;
   }
 
   /**
@@ -38,5 +50,21 @@ public class ItemResponse<T> {
    */
   public Optional<String> getErrorMessage() {
     return Optional.fromNullable(errorMessage);
+  }
+
+  /**
+   * @return the response status
+   */
+  public Status getResponseStatus() {
+    return responseStatus;
+  }
+
+  /**
+   * Enum of response status.
+   */
+  public enum Status {
+    SUCCESS,  //Indicates a successful response
+    SATISFIED, //Indicates there are no additional responses
+    FAILURE   //Indicates a failure retrieving the response
   }
 }

--- a/tds-item-selection-components/src/main/java/tds/itemselection/services/ItemCandidatesService.java
+++ b/tds-item-selection-components/src/main/java/tds/itemselection/services/ItemCandidatesService.java
@@ -20,6 +20,8 @@ import tds.itemselection.model.OffGradeResponse;
 public interface ItemCandidatesService {
   /**
    * Retrieves the next {@link tds.itemselection.base.ItemCandidatesData} for an exam
+   * If an exam is complete, an ItemCandidatesData with algorithm {@link tds.dll.api.IItemSelectionDLL#SATISFIED}
+   * is returned.
    *
    * @param examId the examId
    * @return {@link tds.itemselection.base.ItemCandidatesData}
@@ -29,10 +31,12 @@ public interface ItemCandidatesService {
 
   /**
    * Retrieves all the available item candidates
+   * If an exam is complete, the list contains a single ItemCandidatesData with algorithm
+   * {@link tds.dll.api.IItemSelectionDLL#SATISFIED}.
    *
    * @param examId the exam item
    * @return the entire list of available {@link tds.itemselection.base.ItemCandidatesData}
-   * @throws ReturnStatusException
+   * @throws ReturnStatusException if there are any issues
    */
   List<ItemCandidatesData> getAllItemCandidates(UUID examId) throws ReturnStatusException;
 
@@ -85,7 +89,6 @@ public interface ItemCandidatesService {
    * @param examId exam id
    * @param designation designation
    * @param segmentKey the segment key
-   * @param reason the reason to add off grade items
    * @return
    * @throws ReturnStatusException
    */

--- a/tds-item-selection-components/src/test/java/tds/itemselection/model/ItemResponseTest.java
+++ b/tds-item-selection-components/src/test/java/tds/itemselection/model/ItemResponseTest.java
@@ -1,0 +1,45 @@
+package tds.itemselection.model;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tds.itemselection.model.ItemResponse.Status.FAILURE;
+import static tds.itemselection.model.ItemResponse.Status.SATISFIED;
+import static tds.itemselection.model.ItemResponse.Status.SUCCESS;
+
+public class ItemResponseTest {
+
+    @Test
+    public void itShouldCreateASuccessfulResponse() {
+        final Object response = new Object();
+        final ItemResponse<Object> itemResponse = new ItemResponse<>(response);
+        assertThat(itemResponse.getResponseData().orNull()).isEqualTo(response);
+        assertThat(itemResponse.getErrorMessage().isPresent()).isFalse();
+        assertThat(itemResponse.getResponseStatus()).isEqualTo(SUCCESS);
+    }
+
+    @Test
+    public void itShouldCreateAFailureResponse() {
+        final String message = "A Failure Message";
+        final ItemResponse<Object> itemResponse = new ItemResponse<>(message);
+        assertThat(itemResponse.getResponseData().isPresent()).isFalse();
+        assertThat(itemResponse.getErrorMessage().orNull()).isEqualTo(message);
+        assertThat(itemResponse.getResponseStatus()).isEqualTo(FAILURE);
+    }
+
+    @Test
+    public void itShouldCreateASatisfiedResponse() {
+        final ItemResponse<Object> itemResponse = new ItemResponse<>(SATISFIED);
+        assertThat(itemResponse.getResponseData().isPresent()).isFalse();
+        assertThat(itemResponse.getErrorMessage().isPresent()).isFalse();
+        assertThat(itemResponse.getResponseStatus()).isEqualTo(SATISFIED);
+    }
+
+    @Test
+    public void itShouldCreateAFailureResponseFromANullItem() {
+        final ItemResponse<Object> itemResponse = new ItemResponse<>((Object)null);
+        assertThat(itemResponse.getResponseData().isPresent()).isFalse();
+        assertThat(itemResponse.getErrorMessage().isPresent()).isTrue();
+        assertThat(itemResponse.getResponseStatus()).isEqualTo(FAILURE);
+    }
+}

--- a/tds-item-selection-components/src/test/java/tds/itemselection/services/impl/ItemSelectionServiceImplTest.java
+++ b/tds-item-selection-components/src/test/java/tds/itemselection/services/impl/ItemSelectionServiceImplTest.java
@@ -1,0 +1,62 @@
+package tds.itemselection.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import tds.dll.api.IItemSelectionDLL;
+import tds.itemselection.base.ItemCandidatesData;
+import tds.itemselection.base.ItemGroup;
+import tds.itemselection.model.AlgorithmType;
+import tds.itemselection.model.ItemResponse;
+import tds.itemselection.selectors.ItemSelector;
+import tds.itemselection.selectors.impl.FieldTestSelector;
+import tds.itemselection.selectors.impl.FixedFormSelector;
+import tds.itemselection.services.ItemCandidatesService;
+import tds.itemselection.services.MsbAssessmentSelectionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static tds.itemselection.model.ItemResponse.Status.SATISFIED;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ItemSelectionServiceImplTest {
+
+    private Map<AlgorithmType, ItemSelector> adaptiveItemSelectors;
+
+    @Mock
+    private ItemCandidatesService mockItemCandidatesService;
+
+    @Mock
+    private MsbAssessmentSelectionService mockMsbAssessmentSelectionService;
+
+    @Mock
+    private FixedFormSelector mockFixedFormSelector;
+
+    @Mock
+    private FieldTestSelector mockFieldTestSelector;
+
+    private ItemSelectionServiceImpl service;
+
+    @Before
+    public void setup() {
+        adaptiveItemSelectors = new HashMap<>();
+        service = new ItemSelectionServiceImpl(adaptiveItemSelectors, mockItemCandidatesService, mockMsbAssessmentSelectionService, mockFixedFormSelector, mockFieldTestSelector);
+    }
+
+    @Test
+    public void itShouldReturnASatisfiedResponseIfThereAreNoAdditionaItems() throws Exception {
+        final UUID examId = UUID.randomUUID();
+        final ItemCandidatesData satisfiedData = new ItemCandidatesData(examId, IItemSelectionDLL.SATISFIED);
+
+        when(mockItemCandidatesService.getItemCandidates(examId)).thenReturn(satisfiedData);
+
+        final ItemResponse<ItemGroup> response = service.getNextItemGroup(examId, false);
+        assertThat(response.getResponseStatus()).isEqualTo(SATISFIED);
+    }
+}


### PR DESCRIPTION
The root issue is that ItemSelectionService#getNextItemGroup needs to return the next item group, if it exists, a "SATISFIED" response if there are no additional item groups, or a failure message if there was an error.
The legacy implementation was returning null with a "Test Completed" error message in the case of there being no additional responses.  This implementation adds a Status enum to the ItemResponse payload for the three response states.